### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ android-parallax-recycleview
 **Step 2.** Add the dependency
 
     dependencies {
-    	compile 'com.github.kanytu:android-parallax-recyclerview:v1.7'
+    	implementation 'com.github.kanytu:android-parallax-recyclerview:v1.7'
     }
 
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.